### PR TITLE
Add .gitkeep to ensure presence of ./backend/static/product_plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,6 @@ cython_debug/
 #.idea/
 
 backend/static/product_plots/*
+!backend/static/product_plots/.gitkeep
+
 frontend/node_modules/**


### PR DESCRIPTION
## Overview

This PR ensures that the `./backend/static/product_plots` directory exists in the repository, which is essential for the proper execution of `./bin/create_plots`.

### Changes
- Added a `.gitkeep` file inside the `./backend/static/product_plots` directory to maintain the directory structure in Git.
- Modified the `.gitignore` file accordingly

### Rationale

The `create_plots` script requires the `./backend/static/product_plots` directory to be present for successful execution. However, since Git doesn't track empty directories, it might be missing when users clone the repository. By adding a `.gitkeep` file, we ensure Git tracks this otherwise empty directory, and the script will run smoothly for everyone who clones or pulls from the repository in the future.

### Testing

1. Clone the repository anew or pull the latest changes.
2. Check that the `./backend/static/product_plots` directory exists.
3. Run the `create_plots` script to ensure it operates without errors related to the missing directory.

Feedback is welcome. Thank you for considering this PR!